### PR TITLE
archive artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,7 @@ pipeline {
         stage('Static Analysis') {
             steps {
                 sh './gradlew pmdMain'
+                archiveArtifacts artifacts: '**/build/reports/**', fingerprint: true
             }
         }
     }


### PR DESCRIPTION
Archive all build reports. Will this archive /pmd and /tests or just /pmd? Do we need to run this at each stage? 

edit: the answer appears to be that it will archive it all: http://ec2-107-21-21-140.compute-1.amazonaws.com/job/doge-life/job/doge-tasks-service/job/archive-artifacts/