### PR TITLE
Build a WAR instead of JAR for application server deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,4 @@
+#!groovy
 pipeline {
     agent any
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,10 @@ apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'org.springframework.boot'
 apply plugin: 'pmd'
+apply plugin: 'war'
+apply plugin: 'maven-publish'
 
-jar {
+war {
     baseName = 'doge-tasks-service'
     version = '0.0.1-SNAPSHOT'
 }
@@ -38,11 +40,25 @@ ruleSets = [
 				 ]
 }
 
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            groupId 'org.doge'
+            artifactId 'doge-tasks-service'
+            version = war.version
+            from components.web
+        }
+    }
+}
+
 dependencies {
     compile('org.springframework.boot:spring-boot-starter-web')
     compile('org.springframework.boot:spring-boot-starter-data-jpa')
     compileOnly('org.projectlombok:lombok')
 
+    providedRuntime('org.springframework.boot:spring-boot-starter-tomcat')
+
     runtime('org.hsqldb:hsqldb')
     testCompile('org.springframework.boot:spring-boot-starter-test')
 }
+

--- a/src/main/java/org/doge/DogeTasksServiceApplication.java
+++ b/src/main/java/org/doge/DogeTasksServiceApplication.java
@@ -2,9 +2,16 @@ package org.doge;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.web.support.SpringBootServletInitializer;
 
 @SpringBootApplication
-public class DogeTasksServiceApplication {
+public class DogeTasksServiceApplication extends SpringBootServletInitializer {
+
+    @Override
+    protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
+        return application.sources(DogeTasksServiceApplication.class);
+    }
 
     public static void main(String[] args) {
         SpringApplication.run(DogeTasksServiceApplication.class, args);


### PR DESCRIPTION
This adds the WAR plugin to the Gradle build, which builds an artifact that can be deployed to a web application server like Tomcat. There may be additional configuration needed for other application servers like WebLogic, however.