### PR TITLE
Artifactory upload

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,9 @@ pipeline {
             }
         }
         stage('Deploy to Artifactory') {
+            when {
+                branch 'master'
+            }
             steps {
                 sh './gradlew publish'
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,9 @@
 pipeline {
     agent any
 
+    environment {
+        ORG_GRADLE_PROJECT_ARTIFACTORY = credentials('artifactory-deploy')
+    }
     stages {
         stage('Unit Tests') {
             steps {
@@ -12,6 +15,11 @@ pipeline {
             steps {
                 sh './gradlew pmdMain'
                 archiveArtifacts artifacts: '**/build/reports/**', fingerprint: true
+            }
+        }
+        stage('Deploy to Artifactory') {
+            steps {
+                sh './gradlew publish'
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -53,8 +53,8 @@ publishing {
         maven {
             url 'http://ec2-34-207-197-10.compute-1.amazonaws.com/artifactory/app-releases-local'
             credentials {
-                username ARTIFACTORY_USER
-                password ARTIFACTORY_PASS
+                username ARTIFACTORY_USR
+                password ARTIFACTORY_PSW
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'maven-publish'
 
 war {
     baseName = 'doge-tasks-service'
-    version = '0.0.1-SNAPSHOT'
+    version = '0.0.1'
 }
 
 sourceCompatibility = 1.8
@@ -49,6 +49,15 @@ publishing {
             from components.web
         }
     }
+    repositories {
+        maven {
+            url 'http://ec2-34-207-197-10.compute-1.amazonaws.com/artifactory/app-releases-local'
+            credentials {
+                username ARTIFACTORY_USER
+                password ARTIFACTORY_PASS
+            }
+        }
+    }
 }
 
 dependencies {
@@ -61,4 +70,3 @@ dependencies {
     runtime('org.hsqldb:hsqldb')
     testCompile('org.springframework.boot:spring-boot-starter-test')
 }
-

--- a/build.gradle
+++ b/build.gradle
@@ -53,8 +53,12 @@ publishing {
         maven {
             url 'http://ec2-34-207-197-10.compute-1.amazonaws.com/artifactory/app-releases-local'
             credentials {
-                username ARTIFACTORY_USR
-                password ARTIFACTORY_PSW
+                if (project.hasProperty('ARTIFACTORY_USR')) {
+                    username ARTIFACTORY_USR
+                }
+                if (project.hasProperty('ARTIFACTORY_PSW')) {
+                    password ARTIFACTORY_PSW
+                }
             }
         }
     }


### PR DESCRIPTION
This enables the build to publish the WAR and generated POM file to a Maven repository (currently Artifactory on AWS) for a master build. This doesn't upload for feature branches.

You need to set the `ORG_GRADLE_PROJECT_ARTIFACTORY_USR` and `ORG_GRADLE_PROJECT_ARTIFACTORY_PSW` environment variables before running `./gradlew publish`.