### PR TITLE
DOGE-22: Maisam/Remy - moving git update to end of job to avoid multiple simultaneous deploys

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,16 +46,6 @@ pipeline {
                 sh './packer/build'
             }
         }
-        stage('Update Git with Latest Image') {
-            when {
-                branch 'master'
-            }
-            steps {
-                withCredentials([string(credentialsId: 'github-oauth', variable: 'GITHUB_TOKEN')]) {
-                    sh './packer/update_git'
-                }
-            }
-        }
         stage('Deploy to Dev') {
             when {
                 branch 'master'
@@ -66,6 +56,16 @@ pipeline {
                     sh "./terraform/providers/aws/us_east_1_dev/plan ${getAMIFromPackerManifest()}"
                     sh "./terraform/providers/aws/us_east_1_dev/apply ${getAMIFromPackerManifest()}"
                     archiveArtifacts artifacts: "**/terraform.tfstate"
+                }
+            }
+        }
+        stage('Update Git with Latest Image') {
+            when {
+                branch 'master'
+            }
+            steps {
+                withCredentials([string(credentialsId: 'github-oauth', variable: 'GITHUB_TOKEN')]) {
+                    sh './packer/update_git'
                 }
             }
         }


### PR DESCRIPTION
- When our change was merged, it kicked a second build after the manifest.json was pushed to master, causing two instances to be stood up. Moving the step to the end to prevent this.
